### PR TITLE
Condense gulp and hugo commands into `npm run build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,8 @@ Project Structure:
 1. Install [node and npm](https://nodejs.org/en/download/) & ensure that
    installed packages are in the PATH (for gulp etc).
 1. Install the node modules `npm install`
-1. Run:
-    ```
-    gulp scss --production
-    gulp js --production
-    bin/hugo
-    ```
+1. `npm run build` to build a static site in the `public` directory
+
 ## Sync the changes to the site
 
 First build a production version of the site.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "gulp-asset-manifest": "0.0.6",
     "gulp-concat": "^2.6.1",
     "gulp-uglify": "^3.0.0",
-    "gulp-util": "^3.0.8"
+    "gulp-util": "^3.0.8",
+    "hugo-bin": "^0.18.1"
+  },
+  "scripts": {
+    "build": "gulp scss --production; gulp js --production; hugo",
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp-concat": "^2.6.1",
     "gulp-uglify": "^3.0.0",
     "gulp-util": "^3.0.8",
-    "hugo-bin": "^0.18.1"
+    "hugo-bin": "^0.13.0"
   },
   "scripts": {
     "build": "gulp scss --production; gulp js --production; hugo"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "hugo-bin": "^0.18.1"
   },
   "scripts": {
-    "build": "gulp scss --production; gulp js --production; hugo",
+    "build": "gulp scss --production; gulp js --production; hugo"
   }
 }


### PR DESCRIPTION
# What?
- `npm run build` replaces `gulp scss --production; gulp js --production; hugo`
- add hugo to dev dependencies in npm

# Why?
- Saves the developer a bit of time
- hugo should have been in the npm dependencies