### PR TITLE
Allow posts to have no author

### DIFF
--- a/themes/felix/layouts/index.html
+++ b/themes/felix/layouts/index.html
@@ -30,8 +30,12 @@
           <div class="headline-subtitle">
             {{ truncate $subtitleLength "..." .Params.subtitle }}
           </div>
-          {{ $authorPage := (.Site.GetPage "taxonomyTerm" "authors" (index .Params.authors 0)) }}
-          <span class="headline-author">By {{ $authorPage.Params.name }}</span>
+          {{ if isset .Params "authors" -}}
+            {{ $authorPage := (.Site.GetPage "taxonomyTerm" "authors" (index .Params.authors 0)) }}
+            <span class="headline-author">By {{ $authorPage.Params.name }}</span>
+          {{- else }}
+            <span class="headline-author">No Author</span>
+          {{- end }}
         </div>
       </div>
     {{ end }}
@@ -67,8 +71,12 @@
                   {{ truncate $subtitleLength "..." .Params.subtitle }}
                 </div>
                 <div class="section-post-byline">
-                  {{ $authorPage := (.Site.GetPage "taxonomyTerm" "authors" (index .Params.authors 0)) }}
-                  <span class="author">By {{ $authorPage.Params.name }}</span>
+                  {{ if isset .Params "authors" -}}
+                    {{ $authorPage := (.Site.GetPage "taxonomyTerm" "authors" (index .Params.authors 0)) }}
+                    <span class="author">By {{ $authorPage.Params.name }}</span>
+                  {{- else }}
+                    <span class="author">No Author</span>
+                  {{- end }}
                 </div>
               </div>
             </div>

--- a/themes/felix/layouts/taxonomy/category.html
+++ b/themes/felix/layouts/taxonomy/category.html
@@ -61,8 +61,12 @@
             {{ truncate $subtitleLength "..." .Params.subtitle }}
           </div>
           <div class="section-post-byline">
+          {{ if isset .Params "authors" -}}
             {{ $authorPage := (.Site.GetPage "taxonomyTerm" "authors" (index .Params.authors 0)) }}
             <span class="author">By {{ $authorPage.Params.name }}</span>
+          {{- else }}
+            <span class="author">No Author</span>
+          {{- end }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
https://github.com/FelixOnline/v2/blob/master/content/articles/2018-10-23-2018-nobel-prize-in-medicine-the-fight-against-cancer.md seems to have no author and that was causing the site to break, if this is a feature the site needs then merge this PR. However, I think it'd be preferable to always have an author to avoid catching blank authors all over the place.