### PR TITLE
Fix category case matching issue

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -199,11 +199,11 @@ params:
         - artur_donaldson
         - monami_miyamoto
       navbar: false
-    - name: GSU
+    - name: gsu
       colour: "000000"
       email: gsu.president@imperial.ac.uk
       display: Postgraduate
       editors:
         - andy_djaba
       navbar: false
-      
+

--- a/content/articles/2019-04-08-super-talents-need-super-food-a-pg-perspective-on-h-bar-cuts.md
+++ b/content/articles/2019-04-08-super-talents-need-super-food-a-pg-perspective-on-h-bar-cuts.md
@@ -8,7 +8,7 @@ authors:
   - ute_thiermann
 date: '2019-03-01 17:00:00'
 categories:
-  - GSU
+  - gsu
 ---
 Life is our best teacher about how the biggest crises can be turned into the most fundamental opportunities for change. If there is one good thing about the h-bar food-cut tragedy, then it is the chance to take a step back and rethink how we provide and procure food at Imperial in general. The recent decision to cut the SCR breakfast and the evening supper service in h-bar are only examples of the many ways in which students, and staff, are increasingly challenged if they want to follow a healthy life-style. 
 

--- a/themes/felix/layouts/index.html
+++ b/themes/felix/layouts/index.html
@@ -43,7 +43,7 @@
 <div class="sections">
   {{ range $category := .Site.Params.displayCategories }}
     {{ $name := $category.Name }}
-    {{ $categoryPage := ($.Site.GetPage "taxonomyTerm" "categories" $name) }}
+    {{ $categoryPage := ($.Site.GetPage "taxonomyTerm" "categories" (lower $name)) }}
     {{ $pageCount := len (where $.Site.Pages ".Params.categories" "intersect" (slice $name)) }}
 
     {{ if (gt $pageCount 0) }}


### PR DESCRIPTION
Categories on article pages need to be linked to on the lower case of
the name as this is the slug hugo uses in the path. Probably easiest to
keep it consistent on lower case category names for this reason since
we have `display` in the catefory setting to change how it's displayed.

Signed-off-by: charlieegan3 <charlieegan3@users.noreply.github.com>