### PR TITLE
Remove draft status from article

### DIFF
--- a/content/articles/2019-09-23-the-truth-isnt-always-satisfying.md
+++ b/content/articles/2019-09-23-the-truth-isnt-always-satisfying.md
@@ -1,0 +1,29 @@
+---
+title: >
+  The Truth Isn't Always Satisfying
+subtitle: >
+  Conspiracy = a secret plan by a group to do something unlawful or harmful
+date: "2019-09-23 21:51:48 +0000"
+published: true
+headline: true
+featured: true
+imported: true
+aliases:
+comments:
+categories:
+ - arts
+tags:
+authors:
+ - amanda_hertzberg
+highlights:
+---
+There’s no doubt that a large chunk of the population are at least fascinated by conspiracy theories. Youtuber Shane Dawson has compilations of them on his youtube channel, each video with almost as many views as the British population. And we all have that friend who stays up at night listening to conspiracy podcasts. Maybe you are that friend. Even if you’re not that friend, if you don’t believe the stories, you can definitely have respect for the meticulous and hard work that entails working them out, the eye for detail and the dedication one must have. The more of this seemingly very delicately worked out evidence there is, no matter if false, the smaller the leap of faith feels between scepticism and belief.
+
+You name it - there’s a conspiracy theory about it.
+So what happens when you quite literally put them all together in a small-scale theatre production, hire three brilliant actors and get a bunch of amazing props? You get New Diorama Theatre’s production _Conspiracy_. The whole of this 75 minute play takes place in one room, yet it travels to New York Rockefeller Center, Hollywood and to the moon and back. It starts with three people apparently preparing to start recording some sort of  TV segment. They have their scripts and props ready, and a microphone propped up against the middle speaker, Rose. They start by describing a photograph the audience has not yet seen, and they generate a lot of laughter in the audience whilst doing so. It is Rose Wardlaw’s stubbornness and rockhard subscription to correctness that renders this scene so humorous. The play stays humorous throughout the duration, even in its darkest moments it is a comedy through and through. After a few attempts of describing this photo I think most people get an idea of it, and it is no surprise when the 1932 photo “Lunch atop a Skyscraper” is revealed.
+
+I can’t tell whether the acting or the screenplay is what takes this play from mediocre to excellent. At times I can’t tell if the actors are still acting or if something actually went off the script. It seems to be one of those shows that evolves, a few extra jokes added every night, definitely interacting with the audience. The best kind of play. I can’t talk too much about the plot without spoiling anything, and I definitely don’t want to spoil this one. Rose Wardlaw starts off the show as a strong lead actress, but I left feeling like it was really Shannon Hayes that carried this play over and beyond with her absolutely amazing version of Elvis Presley.
+
+Conspiracy is really easy to watch. It never gets annoying, weird or too arthouse-y for the mass crowd. It’s a bring-your-friends and have-a-couple-of-beers kind of lighthearted entertainment. Perfect for the freshers that want to venture out in London, towards the dark headquarters of UCL.
+
+_- 4.5 stars_


### PR DESCRIPTION
Here I include the article again, this time with `draft: true` removed.

Articles can't have published and draft set to true.

I found this by clicking the red cross and looking at the logs here: https://circleci.com/gh/FelixOnline/v2/5911?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link